### PR TITLE
feat: granular context controls (include, exclude, size limits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ make build
 Generate context from a single source.
 
 ```bash
-# Process a single path (local directory) with additional ignore patterns
-ai-context /path/to/directory  -i "tests,docs,*doc.*"
+# Process a single path (local directory) with additional exclude patterns
+ai-context /path/to/directory  -e "tests,docs,*doc.*"
+
+# Only include specific file types with max size limit
+ai-context /path/to/directory -i "*.go,*.md" -s 5242880
 
 # Process one URL (GitHub repo or YouTube Video or Webpage URL)
 ai-context https://www.youtube.com/watch?v=video_id
@@ -57,7 +60,9 @@ GH_TOKEN=$(cat /secrets/GH.PAT) ai-context https://github.com/ORG/REPO
 ```
 
 **Flags:**
-- `--ignore, -i` - Additional patterns to ignore (e.g., 'tests,docs')
+- `--include, -i` - Include files matching globs (e.g., '*.go,*.md')
+- `--exclude, -e` - Exclude files matching globs (e.g., 'tests,docs')
+- `--max-size, -s` - Maximum file size in bytes to include (default 10MB)
 - `--debug` - Enable debug logging
 - `--for-ai` - AI-friendly output (plain text, piped input)
 
@@ -85,8 +90,19 @@ ai-context -f listfile
 ## Tips and Notes
 
 - For directory path (in URL or listfile mode), the path should either start with `/` (absolute) or with `./` or `../` (relative). For current directory, always use `./` for correct regex matching.
-- Do a `head -n 200 context/FILE.md` (or 500 lines) to view the content tree of the processed code base or directory to see what's been included. Then refine your `-i` flag arguments to ignore additional patterns.
+- Do a `head -n 200 context/FILE.md` (or 500 lines) to view the content tree of the processed code base or directory to see what's been included. Then refine your `-e` flag arguments to exclude additional patterns.
 - The `--for-ai` flag produces plain text without ANSI colors, which is easier for AI agents to parse.
+
+## Scenarios
+
+### The "Learn & Implement" Scenario
+`ai-context -f listfile`
+*Where `listfile` contains your local `internal/` directory and a Medium article URL explaining an architectural pattern.*
+**Use Case:** The user wants an LLM to refactor their existing `internal/` packages using a specific pattern described in a Medium article. AI-Context will output markdown of both the codebase and the article content, ready to pipe to your LLM prompt.
+
+### The "Bug Hunt" Scenario
+`ai-context https://github.com/org/repo -i "pkg/math/*.go"`
+**Use Case:** Pulls down only the specific logic paths from a GitHub repository to save token limits when asking an LLM to find a bug.
 
 ## Acknowledgments
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,10 +15,12 @@ import (
 )
 
 var cmdFlags struct {
-	threads    int
-	url        string
-	listFile   string
-	ignoreList []string
+	threads      int
+	url          string
+	listFile     string
+	includeGlobs []string
+	excludeGlobs []string
+	maxSize      int64
 }
 
 var AppVersion = "dev-build"
@@ -62,7 +64,7 @@ var rootCmd = &cobra.Command{
 				utils.PrintFatal("failed to read list file", scanner.Err())
 			}
 		}
-		aicontext.Handler(urls, cmdFlags.ignoreList, cmdFlags.threads, false)
+		aicontext.Handler(urls, cmdFlags.includeGlobs, cmdFlags.excludeGlobs, cmdFlags.maxSize, cmdFlags.threads, false)
 	},
 }
 
@@ -102,5 +104,7 @@ func init() {
 
 	rootCmd.Flags().StringVarP(&cmdFlags.listFile, "file", "f", "", "File with list of URLs to process")
 	rootCmd.Flags().IntVarP(&cmdFlags.threads, "threads", "t", 10, "Number of threads to use for processing")
-	rootCmd.Flags().StringSliceVarP(&cmdFlags.ignoreList, "ignore", "i", []string{}, "Additional patterns to ignore (e.g., 'tests,docs'); helpful with GitHub or local directories")
+	rootCmd.Flags().StringSliceVarP(&cmdFlags.includeGlobs, "include", "i", []string{}, "Include files matching globs (e.g., '*.go,*.md')")
+	rootCmd.Flags().StringSliceVarP(&cmdFlags.excludeGlobs, "exclude", "e", []string{}, "Exclude files matching globs (e.g., 'tests,docs')")
+	rootCmd.Flags().Int64VarP(&cmdFlags.maxSize, "max-size", "s", 10485760, "Maximum file size in bytes to include (default 10MB)")
 }

--- a/internal/aicontext/handler.go
+++ b/internal/aicontext/handler.go
@@ -68,13 +68,15 @@ func cleanURL(rawURL string) (string, error) {
 	return parsedURL.String(), nil
 }
 
-func handlerWorker(toProcess input, resultChan chan result, ignoreList []string) {
+func handlerWorker(toProcess input, resultChan chan result, includeGlobs []string, excludeGlobs []string, maxSize int64) {
 	switch toProcess.urlType {
 	case "gh":
 		output := path.Join("context", "gh-"+GetOutFileName(toProcess.url))
 		codeProcessor := NewProcessor(ProcessorConfig{
-			OutputPath:        output,
-			AdditionalIgnores: ignoreList,
+			OutputPath:   output,
+			IncludeGlobs: includeGlobs,
+			ExcludeGlobs: excludeGlobs,
+			MaxSize:      maxSize,
 		})
 		utils.PrintIndentedRunning(fmt.Sprintf("%s: starting collection", toProcess.url))
 		err := codeProcessor.ProcessGitHubURL(toProcess.url)
@@ -86,8 +88,10 @@ func handlerWorker(toProcess input, resultChan chan result, ignoreList []string)
 	case "dir":
 		output := path.Join("context", "dir-"+GetOutFileName(toProcess.url))
 		codeProcessor := NewProcessor(ProcessorConfig{
-			OutputPath:        output,
-			AdditionalIgnores: ignoreList,
+			OutputPath:   output,
+			IncludeGlobs: includeGlobs,
+			ExcludeGlobs: excludeGlobs,
+			MaxSize:      maxSize,
 		})
 		err := codeProcessor.ProcessDirectory(toProcess.url)
 		if err != nil {
@@ -123,7 +127,7 @@ func handlerWorker(toProcess input, resultChan chan result, ignoreList []string)
 	}
 }
 
-func Handler(urls []string, ignoreList []string, threads int, detailLog bool) {
+func Handler(urls []string, includeGlobs []string, excludeGlobs []string, maxSize int64, threads int, detailLog bool) {
 	var cleanedUrls []string
 	for _, u := range urls {
 		cleaned, err := cleanURL(u)
@@ -205,7 +209,7 @@ func Handler(urls []string, ignoreList []string, threads int, detailLog bool) {
 			go func(toProcess input) {
 				defer workersWG.Done()
 				defer func() { <-semaphore }()
-				handlerWorker(toProcess, resultChan, ignoreList)
+				handlerWorker(toProcess, resultChan, includeGlobs, excludeGlobs, maxSize)
 				progCh <- 1
 			}(toProcess)
 		}

--- a/internal/aicontext/ignores.go
+++ b/internal/aicontext/ignores.go
@@ -5,37 +5,64 @@ import (
 	"strings"
 )
 
-type IgnorePatterns struct {
-	defaultPatterns []string
-	customPatterns  []string
+type PathFilter struct {
+	defaultExcludes []string
+	includePatterns []string
+	excludePatterns []string
 }
 
-func newIgnorePatterns(additionalPatterns []string) *IgnorePatterns {
-	customPatterns := make([]string, len(additionalPatterns))
-	for i, pattern := range additionalPatterns {
-		customPatterns[i] = "*/" + pattern
-	}
-	return &IgnorePatterns{
-		defaultPatterns: defaultIgnores,
-		customPatterns:  customPatterns,
-	}
-}
-
-func (ip *IgnorePatterns) shouldIgnore(path string) bool {
-	for _, pattern := range ip.defaultPatterns {
-		if matched, _ := filepath.Match(pattern, filepath.Base(path)); matched {
-			return true
+func newPathFilter(includePatterns []string, excludePatterns []string) *PathFilter {
+	parsedIncludes := make([]string, 0)
+	for _, p := range includePatterns {
+		if p != "" {
+			parsedIncludes = append(parsedIncludes, p)
 		}
 	}
-	for _, pattern := range ip.customPatterns {
+
+	parsedExcludes := make([]string, len(excludePatterns))
+	for i, pattern := range excludePatterns {
+		parsedExcludes[i] = "*/" + pattern
+	}
+
+	return &PathFilter{
+		defaultExcludes: defaultIgnores,
+		includePatterns: parsedIncludes,
+		excludePatterns: parsedExcludes,
+	}
+}
+
+func (pf *PathFilter) shouldInclude(path string, isDir bool) bool {
+	for _, pattern := range pf.defaultExcludes {
+		if matched, _ := filepath.Match(pattern, filepath.Base(path)); matched {
+			return false
+		}
+	}
+
+	for _, pattern := range pf.excludePatterns {
 		if matched, _ := filepath.Match(pattern, path); matched {
-			return true
+			return false
 		}
 		if matched, _ := filepath.Match(strings.TrimPrefix(pattern, "*/"), filepath.Base(path)); matched {
-			return true
+			return false
 		}
 	}
-	return false
+
+	if len(pf.includePatterns) > 0 {
+		if isDir {
+			return true
+		}
+		for _, pattern := range pf.includePatterns {
+			if matched, _ := filepath.Match(pattern, filepath.Base(path)); matched {
+				return true
+			}
+			if matched, _ := filepath.Match(pattern, path); matched {
+				return true
+			}
+		}
+		return false
+	}
+
+	return true
 }
 
 func isBinary(content []byte) bool {

--- a/internal/aicontext/source-context.go
+++ b/internal/aicontext/source-context.go
@@ -27,13 +27,15 @@ type Output struct {
 }
 
 type ProcessorConfig struct {
-	OutputPath        string
-	AdditionalIgnores []string
+	OutputPath   string
+	IncludeGlobs []string
+	ExcludeGlobs []string
+	MaxSize      int64
 }
 
 type Processor struct {
-	config         ProcessorConfig
-	ignorePatterns *IgnorePatterns
+	config ProcessorConfig
+	filter *PathFilter
 }
 
 const markdownTemplate = `# Source Code Context
@@ -63,8 +65,8 @@ Generated on: {{.GenerationDate}}
 
 func NewProcessor(config ProcessorConfig) *Processor {
 	return &Processor{
-		config:         config,
-		ignorePatterns: newIgnorePatterns(config.AdditionalIgnores),
+		config: config,
+		filter: newPathFilter(config.IncludeGlobs, config.ExcludeGlobs),
 	}
 }
 
@@ -114,13 +116,16 @@ func (p *Processor) processDirectory(root string) (*Output, error) {
 		if err != nil {
 			return err
 		}
-		if p.ignorePatterns.shouldIgnore(relPath) {
+		if !p.filter.shouldInclude(relPath, info.IsDir()) {
 			if info.IsDir() {
 				return filepath.SkipDir
 			}
 			return nil
 		}
 		if info.IsDir() {
+			return nil
+		}
+		if p.config.MaxSize > 0 && info.Size() > p.config.MaxSize {
 			return nil
 		}
 		content, err := os.ReadFile(path)
@@ -221,7 +226,7 @@ func (p *Processor) generateDirectoryTree(root string) string {
 		if err != nil {
 			return err
 		}
-		if p.ignorePatterns.shouldIgnore(relPath) {
+		if !p.filter.shouldInclude(relPath, info.IsDir()) {
 			if info.IsDir() {
 				return filepath.SkipDir
 			}


### PR DESCRIPTION
This PR introduces granular file filtering mechanisms to the `ai-context` project, allowing users to better manage their AI token budgets by targeting specific files and omitting irrelevant, bulky artifacts.

Key changes:
1. Replaced the simple `ignoreList` flag with an explicit `-i` (`--include`), `-e` (`--exclude`), and `-s` (`--max-size`).
2. Configured file path matching correctly using `filepath.Match` via the refactored `PathFilter` component.
3. Updated logic in `processDirectory` and `generateDirectoryTree` to skip paths via `shouldInclude()` and size limit assessments.
4. Expanded `README.md` to reflect these features with illustrative real-world examples ("Bug Hunt", "Learn & Implement").

---
*PR created automatically by Jules for task [17708558237133574544](https://jules.google.com/task/17708558237133574544) started by @Tanq16*